### PR TITLE
Prevent multiple labels in drop zone

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -17,8 +17,18 @@ function dragOver(event) {
     event.preventDefault();
 }
 
+// function drop(event) {
+//     event.preventDefault();
+//     this.appendChild(currentDraggedElement);
+//     currentDraggedElement = null;
+// }
+
 function drop(event) {
     event.preventDefault();
+    // Check if the drop zone already has a label
+    if (this.querySelector('.label')) {
+        return; // Exit if there's already a label
+    }
     this.appendChild(currentDraggedElement);
     currentDraggedElement = null;
 }


### PR DESCRIPTION
Updated the drop event handler to check if a label already exists in the drop zone before appending a new one. This prevents multiple labels from being added to the same drop area.